### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Be advised there might be mistakes here, but I'll leave it up as a summary
 ### Background
 Tor hidden service desc_id's are deterministic and if there is no 'descriptor cookie' anyone can determined
 the desc_id's for a HS at an arbitrary point in time. In fact this is required as this is the mechanism by
-which OP's request hidden service descriptors from the HS directories. They are calulated as follows:
+which OP's request hidden service descriptors from the HS directories. They are calculated as follows:
 
     descriptor-id = H(permanent-id | H(time-period | descriptor-cookie | replica))
 


### PR DESCRIPTION
@DonnchaC, I've corrected a typographical error in the documentation of the [tor-hsdir-research](https://github.com/DonnchaC/tor-hsdir-research) project. Specifically, I've changed calulate to calculate. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
